### PR TITLE
fixed mixed array and dict style in docker-compose.yml for environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   s3fs:
     image: xueshanf/s3fs:latest
     environment:
-      - AWSACCESSKEYID: FOOBAR
-      - AWSSECRETACCESSKEY: FOOBARBAZ
+      AWSACCESSKEYID: FOOBAR
+      AWSSECRETACCESSKEY: FOOBARBAZ
     cap_add:
       - MKNOD
       - SYS_ADMIN


### PR DESCRIPTION
@xueshanf I'm sorry, but I mixed up dict and array style (https://docs.docker.com/v1.6/compose/yml/#environment)

Now its correct and I double-checked and tested it :innocent: 
