### PR TITLE
Feature/update to 1.83

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Xueshan Feng <xueshan.feng@gmail.com>
 
-ENV VERSION 1.82
+ENV VERSION 1.83
 
 RUN apt-get update -qq
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 docker-s3fs
 ===========
 
-**[S3fs][s3fs]** docker build for version 1.80. 
+**[S3fs][s3fs]** docker build for version 1.83. 
 
 - [Docker engine after 1.10](#docker-egnine-after-1.10)
 - [Docker engine before 1.10](#docker-engine-before-1.10)


### PR DESCRIPTION
Bumps s3fs version to 1.83
I've tested this on some machines and it seems to be working as before. The setup was using hosts Ubuntu 16.04 hosts, with docker API 1.30 (17.06.1-ce)

Sorry about the diff, but the last commit just removes blank spaces.